### PR TITLE
Add help to display available commands.

### DIFF
--- a/src/dotrun_docker/__init__.py
+++ b/src/dotrun_docker/__init__.py
@@ -116,6 +116,9 @@ def cli(args=None):
     if command == "exec":
         return dotrun.exec(arguments.remainder or ["bash"])
 
+    if command == "help":
+        return dotrun.help()
+
     if command == "install":
         return dotrun.install(force=True)
 

--- a/src/dotrun_docker/__init__.py
+++ b/src/dotrun_docker/__init__.py
@@ -29,12 +29,18 @@ class RawWithDefaultsFormatter(
     pass
 
 
+def get_commands():
+    return "The following commands have been provided by this project's package.json.\n\n{}".format(
+        os.popen("yarn run --non-interactive").read()
+    )
+
 cli_parser = ArgumentParser(
     description=(
         "Containerized project-level dependency management and "
         "package.json commands"
     ),
     formatter_class=RawWithDefaultsFormatter,
+    epilog=get_commands()
 )
 
 # Options
@@ -115,9 +121,6 @@ def cli(args=None):
 
     if command == "exec":
         return dotrun.exec(arguments.remainder or ["bash"])
-
-    if command == "help":
-        return dotrun.help()
 
     if command == "install":
         return dotrun.install(force=True)

--- a/src/dotrun_docker/models.py
+++ b/src/dotrun_docker/models.py
@@ -203,6 +203,13 @@ class Project:
 
         return result
 
+    def help(self):
+        """
+        Display a list of commands provided by this project.
+        """
+
+        self.exec(["yarn", "run", "--non-interactive"])
+
     def terminate_background_processes(self):
         for process in self._background_processes:
             process.terminate()

--- a/src/dotrun_docker/models.py
+++ b/src/dotrun_docker/models.py
@@ -203,13 +203,6 @@ class Project:
 
         return result
 
-    def help(self):
-        """
-        Display a list of commands provided by this project.
-        """
-
-        self.exec(["yarn", "run", "--non-interactive"])
-
     def terminate_background_processes(self):
         for process in self._background_processes:
             process.terminate()


### PR DESCRIPTION
## Done
- Add `dotrun help` command to display available scripts in a project.

## How to QA
1. Check-out this branch
2. Build this image `docker build . --tag canonicalwebteam/dotrun-image:local`
3. Run this image `docker run -it -p 8004:8004 canonicalwebteam/dotrun-image:local /bin/bash`
4. Get a project and display the help:
  - `git clone https://github.com/canonical-web-and-design/snapcraft.io/`
  - `cd snapcraft.io`
5. Run `dotrun help` and it should display the scripts in that project.

## Issue / Card
Fixes: https://github.com/canonical/dotrun/issues/106.
