### PR TITLE
Add missing npm dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN apt-get install --yes \
     libatk1.0-0 libatspi2.0-0 libcairo2 libcups2 libdrm2 \
     libgbm1 libnss3 libpango-1.0-0 libx11-6 libxau6 libxcb1 \
     libxcomposite1 libxdamage1 libxdmcp6 libxext6 libxfixes3 \
-    libxkbcommon-x11-0 libxrandr2 nodejs haproxy libwayland-client0
+    libxkbcommon-x11-0 libxrandr2 nodejs haproxy libwayland-client0 \
+    npm
 
 # Update npm and install yarn
 RUN npm install --location=global npm


### PR DESCRIPTION
## Done
- added missing npm dependency to fix jenkins build

## How to QA
1. Check-out this branch
2. Build this image `docker build . --tag canonicalwebteam/dotrun-image:local`
3. Run this image `docker run -it -p 8004:8004 canonicalwebteam/dotrun-image:local /bin/bash`
4. Run a project
  - `git clone https://github.com/canonical-web-and-design/snapcraft.io/`
  - `cd snapcraft.io`
  - `dotrun`

`dotrun` should install the dependencies and run the project. Once you see this output:
```
Listening at: http://0.0.0.0:8004
```

Visit http://localhost:8004 and check that the website is running.
