### PR TITLE
Releases/1.1.0 rc1

### DIFF
--- a/.github/workflows/publish-version.yaml
+++ b/.github/workflows/publish-version.yaml
@@ -1,0 +1,39 @@
+name: Publish Tag
+
+on:
+  push:
+    branches:
+      - "release/*"
+
+jobs:
+  extract_version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Extract version from setup.py
+        id: extract_version
+        run: |
+          DOTRUN_VERSION=$(sed -n 's/^.*version="\(\S*\)".$/\1/p' src/setup.py) | echo "DOTRUN_VERSION=$DOTRUN_VERSION" >> $GITHUB_ENV
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: canonicalwebteam/dotrun-image:${{ env.DOTRUN_VERSION }}
+    

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - 'main'
-  schedule:
-    - cron: "0 0 1 * *"  # Release a fresh image every month
 
 jobs:
   publish:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+*.egg-info/
+dist/
+src/build/
+env/
+env*/
+.venv/
+__pycache__/
+*.bz2
+environments/
+.vscode/
+.dotrun.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project is a docker image for developing Node.js and Python web projects. I
 ## Image Features
 
 - Based on ubuntu:focal
-- Python 3.8
+- Python 3.10
 - Node 20 LTS
 - Yarn
 - dotrun-docker
@@ -51,6 +51,25 @@ To QA any changes to this image, you probably want to build a local image with D
 
 `docker build . --tag canonicalwebteam/dotrun-image:local`
 
+### Using python
+
+You should probably create a virtualenv, and then install dotrun-docker.
+```bash
+pip uninstall dotrun-docker
+cd src
+pip install .
+```
+
+## Using this image with dotrun
+
+`dotrun-image` can be used with `dotrun 2.3.0`  by building a docker image, and specifying the local image name when running dotrun, for example:
+```bash
+docker build . --tag canonicalwebteam/dotrun-image:local
+cd snapcraft.io
+dotrun --image canonicalwebteam/dotrun-image:local install
+dotrun --image canonicalwebteam/dotrun-image:local serve
+```
+
 ## Releasing
 
 Changes to the default branch will trigger a new release using GitHub Actions.
@@ -58,6 +77,7 @@ Changes to the default branch will trigger a new release using GitHub Actions.
 - Released to [Docker Hub canonicalwebteam/dotrun-image](https://hub.docker.com/r/canonicalwebteam/dotrun-image/)
 - Architectures: AMD64 and ARM64
 
-### Auto-releases
+### Releasing specific versions
 
-This image is automatically built and released every month. This is to ensure dependencies are up to date on local development when using [dotrun](https://github.com/canonical/dotrun).
+Update the version in setup.py, and push the changes to a new branch called `release/<version>` e.g `release/1.2.0-rc1`. This will trigger a new release and publish the tagged image to dockerhub.
+

--- a/src/dotrun_docker/models.py
+++ b/src/dotrun_docker/models.py
@@ -161,14 +161,15 @@ class Project:
             self.env["PATH"] = self.pyenv_path + "/bin:" + self.env["PATH"]
             self.env.pop("PYTHONHOME", None)
 
-            if not os.path.isfile(f"{self.pyenv_path}/bin/python3.8"):
+            # This hard requirement can be removed once other python versions
+            # have been tested with dotrun on canonical web projects
+            if not os.path.isfile(f"{self.pyenv_path}/bin/python3.10"):
                 self.log.note(
-                    "Dotrun was updated to use Python 3.8! This project "
-                    "seems to be using a previous Python environment."
+                    "Dotrun strictly runs on Python 3.10! This project "
+                    "seems to be using a different Python environment."
                 )
-                self.log.step("Creating new Python environment")
                 self._clean_python_env()
-                self._install_python_dependencies(force=True)
+                sys.exit(1)
 
             self.log.step(
                 f"$ {' '.join(commands)}",

--- a/src/setup.py
+++ b/src/setup.py
@@ -4,7 +4,10 @@
 import sys
 from setuptools import setup
 
-assert sys.version_info >= (3, 10), "dotrun-docker requires Python 3.10 or newer"
+assert sys.version_info >= (
+    3,
+    10,
+), "dotrun-docker requires Python 3.10 or newer"
 
 setup(
     name="dotrun-docker",

--- a/src/setup.py
+++ b/src/setup.py
@@ -4,11 +4,11 @@
 import sys
 from setuptools import setup
 
-assert sys.version_info >= (3, 8), "dotrun-docker requires Python 3.8 or newer"
+assert sys.version_info >= (3, 10), "dotrun-docker requires Python 3.10 or newer"
 
 setup(
     name="dotrun-docker",
-    version="1.0.1",
+    version="1.1.0-rc1",
     packages=["dotrun_docker"],
     install_requires=[
         "ipdb",


### PR DESCRIPTION
## Done
- Updated python to python 3.10
- Added a /releases branch to publish on, such that updates to the dotrun-image can be tested downstream before being merged into main

## How to QA
1. Check-out this branch
2. Build this image `docker build . --tag canonicalwebteam/dotrun-image:local`
3. Run this image `docker run -it -p 8004:8004 canonicalwebteam/dotrun-image:local /bin/bash`
4. Run a project
  - `git clone https://github.com/canonical-web-and-design/snapcraft.io/`
  - `cd snapcraft.io`
  - `dotrun`
`dotrun` should install the dependencies and run the project. Once you see this output:
```
Listening at: http://0.0.0.0:8004
```
- Visit http://localhost:8004 and check that the website is running.
5. Create a new release
  - Make a small change to the project and publish it at /releases/test-release. After the publish action completes, you should be able to pull it using
```bash
docker pull canonicalwebteam/dotrun-image:test-release
```