### PR TITLE
Publish releases on separate branch

### DIFF
--- a/.github/workflows/publish-version.yaml
+++ b/.github/workflows/publish-version.yaml
@@ -1,0 +1,39 @@
+name: Publish Tag
+
+on:
+  push:
+    branches:
+      - "release/*"
+
+jobs:
+  extract_version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Extract version from setup.py
+        id: extract_version
+        run: |
+          DOTRUN_VERSION=$(sed -n 's/^.*version="\(\S*\)".$/\1/p' src/setup.py) | echo "DOTRUN_VERSION=$DOTRUN_VERSION" >> $GITHUB_ENV
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: canonicalwebteam/dotrun-image:${{ env.DOTRUN_VERSION }}
+    

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - 'main'
-  schedule:
-    - cron: "0 0 1 * *"  # Release a fresh image every month
 
 jobs:
   publish:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+*.egg-info/
+dist/
+src/build/
+env/
+env*/
+.venv/
+__pycache__/
+*.bz2
+environments/
+.vscode/
+.dotrun.json

--- a/src/setup.py
+++ b/src/setup.py
@@ -8,7 +8,7 @@ assert sys.version_info >= (3, 8), "dotrun-docker requires Python 3.8 or newer"
 
 setup(
     name="dotrun-docker",
-    version="1.0.1",
+    version="1.0.2",
     packages=["dotrun_docker"],
     install_requires=[
         "ipdb",


### PR DESCRIPTION
## Done
- Added a /releases branch to publish on, such that updates to the dotrun-image can be tested downstream before being merged into main

## How to QA
1. Check-out this branch
2. Build this image `docker build . --tag canonicalwebteam/dotrun-image:local`
3. Run this image `docker run -it -p 8004:8004 canonicalwebteam/dotrun-image:local /bin/bash`
4. Run a project
  - `git clone https://github.com/canonical-web-and-design/snapcraft.io/`
  - `cd snapcraft.io`
  - `dotrun`

`dotrun` should install the dependencies and run the project. Once you see this output:
```
Listening at: http://0.0.0.0:8004
```
- Visit http://localhost:8004 and check that the website is running.
5. Create a new release
- Make a small change to the project and publish it at `releases/test-release`. After the publish action completes, you should be able to pull it using
```bash
docker pull canonicalwebteam/dotrun-image:test-release
```