### PR TITLE
chore: bump node from 20 to 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,14 @@ RUN apt-get update && \
     apt-get install --yes \
     git curl wget build-essential python3-dev python3-pip
 
-# Set up NodeJS 20 repository
-RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
+# Set up Node.js 21 repository
+RUN curl -fsSL https://deb.nodesource.com/setup_21.x | bash -
+
+# Install Node.js and dependencies
+RUN apt-get install --yes nodejs haproxy libwayland-client0
+
+# Install a compatible npm version
+RUN npm install --location=global npm@10
 
 # Install common dependencies used in projects
 RUN apt-get install --yes \

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project is a docker image for developing Node.js and Python web projects. I
 
 - Based on ubuntu:focal
 - Python 3.10
-- Node 20 LTS
+- Node 21 LTS
 - Yarn
 - dotrun-docker
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -12,7 +12,7 @@ assert sys.version_info >= (
 
 setup(
     name="dotrun-docker",
-    version="1.1.0",
+    version="1.2.0",
     packages=["dotrun_docker"],
     install_requires=[
         "ipdb",


### PR DESCRIPTION
## Done
- Bumps Node version from 20 to 21.
- Currently on Charmhub.io, we have some dependency conflicts when trying to upgrade packages as they require a higher version of Node.

## How to QA
1. Run a project
  - `git clone https://github.com/canonical-web-and-design/charmhub.io/`
  - `cd charmhub.io`
  - `dotrun`
2. Check the node version being used
  - `dotrun exec node -v`
  - In this case, it should output `v20.16.0`
3. Check-out this branch
4. Build this image `docker build . --tag canonicalwebteam/dotrun-image:local`
5. Run this image `docker run -it -p 8045:8045 canonicalwebteam/dotrun-image:local /bin/bash`
6. Build Charmhub.io again (`dotrun build`)
7. Node version should now be >= 21.0.0
8. Run Charmhub.io again (`dotrun`)
  - Visit http://localhost:8045 and check that the website is running.
