### PR TITLE
upgrade node from 21 to 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN apt-get update && \
     apt-get install --yes \
     git curl wget build-essential python3-dev python3-pip
 
-# Set up Node.js 21 repository
-RUN curl -fsSL https://deb.nodesource.com/setup_21.x | bash -
+# Set up Node.js 22 repository
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
 
 # Install Node.js and dependencies
 RUN apt-get install --yes nodejs haproxy libwayland-client0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project is a docker image for developing Node.js and Python web projects. I
 
 - Based on ubuntu:focal
 - Python 3.10
-- Node 21 LTS
+- Node 22 LTS
 - Yarn
 - dotrun-docker
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -12,7 +12,7 @@ assert sys.version_info >= (
 
 setup(
     name="dotrun-docker",
-    version="1.2.0",
+    version="1.3.0",
     packages=["dotrun_docker"],
     install_requires=[
         "ipdb",


### PR DESCRIPTION
## Done
- Bumps Node version from 21 to 22.
- Previous bump to 21 needs updated as [node v21 is end of life](https://github.com/nodejs/Release)
- Currently on Charmhub.io, we have some dependency conflicts when trying to upgrade packages as they require a higher version of Node.

## How to QA
1. Run a project
  - `git clone https://github.com/canonical-web-and-design/charmhub.io/`
  - `cd charmhub.io`
  - `dotrun`
2. Check the node version being used
  - `dotrun exec node -v`
  - In this case, it should output `v20.16.0`
3. Check-out this branch
4. Build this image `docker build . --tag canonicalwebteam/dotrun-image:local`
5. `cd` back to charmhub.io and run:
    ```
    dotrun --image canonicalwebteam/dotrun-image:local install
    dotrun --image canonicalwebteam/dotrun-image:local exec node -v
    ```
7. Node version should now be >= 22.0.0
8. Run Charmhub.io using the new image (`dotrun --image canonicalwebteam/dotrun-image:local serve`)
  - Visit http://localhost:8045 and check that the website is running.
