### PR TITLE
add support for custom python versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy
+FROM ubuntu:noble
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
@@ -9,39 +9,38 @@ ENV NO_UPDATE_NOTIFIER=true
 # Install essential system packages
 RUN apt-get update && \
     apt-get install --yes \
-    git curl wget build-essential python3-dev python3-pip
-
-# Set up Node.js 22 repository
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
-
-# Install Node.js and dependencies
-RUN apt-get install --yes nodejs haproxy libwayland-client0
-
-# Install a compatible npm version
-RUN npm install --location=global npm@10
+    git curl wget build-essential \
+    python3-dev python3-pip
 
 # Install common dependencies used in projects
 RUN apt-get install --yes \
     gettext libjpeg-dev libjpeg-progs libmagic1 gpg \
     libmagickwand-dev libpng-dev libpq-dev libsodium-dev \
-    optipng zlib1g-dev libasound2 libatk-bridge2.0-0 \
+    optipng zlib1g-dev libasound2-dev libatk-bridge2.0-0 \
     libatk1.0-0 libatspi2.0-0 libcairo2 libcups2 libdrm2 \
     libgbm1 libnss3 libpango-1.0-0 libx11-6 libxau6 libxcb1 \
     libxcomposite1 libxdamage1 libxdmcp6 libxext6 libxfixes3 \
-    libxkbcommon-x11-0 libxrandr2 nodejs haproxy libwayland-client0
-
-# Update npm and install yarn
-RUN npm install --location=global npm
-RUN npm install --location=global yarn
+    libxkbcommon-x11-0 libxrandr2 haproxy libwayland-client0
 
 # Copy and install dotrun-docker
 WORKDIR /tmp
 ADD src src
-RUN pip3 install ./src
+RUN pip3 install --break-system-packages ./src
 RUN rm -r /tmp/*
 
-# Create ubuntu user
-RUN groupadd --gid 1000 ubuntu
-RUN useradd -rm -d /home/ubuntu -s /bin/bash -g ubuntu -G sudo -u 1000 ubuntu
 USER ubuntu
+
+# Install mise
+RUN curl https://mise.run  | sh
+ENV PATH="/home/ubuntu/.local/bin:/home/ubuntu/.local/share/mise/shims:$PATH"
+# Set Python 3.10 as default
+RUN mise use -g python@3.10
+# Install Node.js and package managers
+RUN mise use -g node@22
+RUN npm config set prefix "/home/ubuntu/.npm-global"
+ENV PATH="/home/ubuntu/.npm-global/bin:$PATH"
+
+RUN npm install --global npm
+RUN npm install --global yarn
+
 WORKDIR /home/ubuntu

--- a/src/dotrun_docker/models.py
+++ b/src/dotrun_docker/models.py
@@ -43,6 +43,15 @@ class State:
         with open(self.filepath, "w") as state_file:
             return json.dump(state, state_file)
 
+    def clean(self):
+        with open(self.filepath, "r") as state_file:
+            state = json.load(state_file)
+        with open(self.filepath, "w") as state_file:
+            # keep project version preferences
+            state = {key: value for key,
+                     value in state.items() if key.endswith("_version")}
+            json.dump(state, state_file)
+
 
 class Logger:
     def note(self, note):
@@ -109,7 +118,7 @@ class Project:
 
         if os.path.isfile(self.statefile_path):
             self.log.step("Removing `.dotrun.json` state file")
-            os.remove(self.statefile_path)
+            self.state.clean()
 
         if os.path.isdir("node_modules"):
             self.log.step("Removing `node_modules`")
@@ -160,25 +169,6 @@ class Project:
             self.env["VIRTUAL_ENV"] = self.pyenv_path
             self.env["PATH"] = self.pyenv_path + "/bin:" + self.env["PATH"]
             self.env.pop("PYTHONHOME", None)
-
-            # This hard requirement can be removed once other python versions
-            # have been tested with dotrun on canonical web projects
-            if not os.path.isfile(f"{self.pyenv_path}/bin/python3.10"):
-                bin_dirs = os.listdir(f"{self.pyenv_path}/bin")
-                # Filter python versions
-                python_versions = [
-                    bin_dir
-                    for bin_dir in bin_dirs
-                    if bin_dir.startswith("python")
-                ]
-                self.log.note(
-                    "Dotrun strictly supports python 3.10, but your "
-                    "virtualenv at .venv is using python version: "
-                    f"{python_versions}."
-                )
-                self._clean_python_env()
-                sys.exit(1)
-
             self.log.step(
                 f"$ {' '.join(commands)}",
                 aside=f"virtualenv `{self.pyenv_dir}`",
@@ -296,19 +286,27 @@ class Project:
 
     def _create_python_environment(self):
         """
-        Create a Python environment using virtualenv
+        Create a Python environment using python3-venv
         """
 
         self.log.note(f"Creating python environment: {self.pyenv_dir}")
+        custom_python_version = self.state["python_version"]
+        if custom_python_version:
+            # use mise en place python version
+            self.exec(
+                [
+                    "mise",
+                    "use",
+                    "-g",
+                    f"python@{custom_python_version}",
+                ]
+            )
         python_path = shutil.which("python3")
-
         self.exec(
             [
-                "virtualenv",
-                "--no-setuptools",
-                "--always-copy",
-                "--python",
                 python_path,
+                "-m",
+                "venv",
                 self.pyenv_path,
             ]
         )

--- a/src/dotrun_docker/models.py
+++ b/src/dotrun_docker/models.py
@@ -48,8 +48,11 @@ class State:
             state = json.load(state_file)
         with open(self.filepath, "w") as state_file:
             # keep project version preferences
-            state = {key: value for key,
-                     value in state.items() if key.endswith("_version")}
+            state = {
+                key: value
+                for key, value in state.items()
+                if key.endswith("_version")
+            }
             json.dump(state, state_file)
 
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -12,7 +12,7 @@ assert sys.version_info >= (
 
 setup(
     name="dotrun-docker",
-    version="1.3.0",
+    version="1.4.0",
     packages=["dotrun_docker"],
     install_requires=[
         "ipdb",


### PR DESCRIPTION
## Done
- Upgrade ubuntu version in Dockerfile
- Set default Python3 version to 3.10
- Use `mise` for nodejs and python installation
- Support custom Python3 versions based on `.dotrun.json`

## How to QA
1. Check-out this branch
2. Build this image `docker build . --tag canonicalwebteam/dotrun-image:local`
3. Run this image `docker run -it -p 8004:8004 canonicalwebteam/dotrun-image:local /bin/bash`
4. Run a project
  - `git clone https://github.com/canonical-web-and-design/snapcraft.io/`
  - `cd snapcraft.io`
  - `dotrun`

`dotrun` should install the dependencies and run the project. Once you see this output:
```
Listening at: http://0.0.0.0:8004
```

Visit http://localhost:8004 and check that the website is running.

## Issue / Card
Fixes WD-14227
